### PR TITLE
feat(code-preview): ability to display iframe within device chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,23 @@ export default function Playground(props) {
 }
 ```
 
+## Show Example in Device Frame
+
+To display a mobile device chrome around the embedded iframe examples, use the `devicePreview` option on `CodePreview`:
+
+```tsx
+export default function Playground(props) {
+  return (
+    <CodePreview
+      devicePreview={true}
+      // Your existing options
+    />
+  );
+}
+```
+
+By default, the mobile device chrome will resemble an Android device. To make the device chrome update to an iPhone, append `?mode=ios` to the source of the iframe. You can make this apply to all iframe examples by updating the `src` rules for the viewport demonstrated above.
+
 ## Advanced
 
 ### Stackblitz Examples

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test --passWithNoTests",
-    "lint": "tsdx lint",
+    "lint": "tsdx lint src",
     "prepare": "tsdx build",
     "size": "size-limit",
     "analyze": "size-limit --why"

--- a/src/components/CodePreview/code-preview.css
+++ b/src/components/CodePreview/code-preview.css
@@ -188,7 +188,7 @@
   width: 100%;
 }
 
-.code-preview iframe.frame-hidden {
+.code-preview .frame-hidden {
   display: none;
 }
 

--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -20,8 +20,6 @@ interface CodePreviewProps {
    * The code snippets to be displayed in the code preview.
    */
   code: { [key: string]: () => {} };
-  title?: string;
-  description?: string;
   source?: string;
   output?: {
     outputs: {
@@ -47,12 +45,21 @@ interface CodePreviewProps {
         }
       | boolean;
   };
+  /**
+   * `true` if the iframe preview should be displayed in a device chrome.
+   */
   devicePreview?: boolean;
+  /**
+   * `true` if the code snippet should be initially expanded.
+   */
   defaultExpanded?: boolean;
   /**
    * The size of the code preview frame. Default is `sm`.
    */
   size?: FrameSize | string;
+  /**
+   * `true` if the code preview should display in dark mode.
+   */
   isDarkMode?: boolean;
   onOpenOutputTarget?: (outputTarget: string, codeBlock: string) => void;
 }

--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -13,6 +13,8 @@ import { CopyCodeButton } from '../CopyCodeButton';
 import { PreviewFrame } from '../PreviewFrame';
 import { FrameSize } from '../../utils/frame-sizes';
 
+import { defineCustomElement } from '../DevicePreview';
+
 interface CodePreviewProps {
   /**
    * The code snippets to be displayed in the code preview.
@@ -45,6 +47,8 @@ interface CodePreviewProps {
         }
       | boolean;
   };
+  devicePreview?: boolean;
+  defaultExpanded?: boolean;
   /**
    * The size of the code preview frame. Default is `sm`.
    */
@@ -62,13 +66,15 @@ export const CodePreview = ({
   controls,
   onOpenOutputTarget,
   isDarkMode,
+  devicePreview,
+  defaultExpanded,
 }: CodePreviewProps) => {
   const codeRef = useRef<HTMLDivElement>(null);
 
   const [outputTarget, setOutputTarget] = useState(
     output?.defaultOutput ?? Object.keys(code)[0]
   );
-  const [codeExpanded, setCodeExpanded] = useState(false);
+  const [codeExpanded, setCodeExpanded] = useState(defaultExpanded ?? true);
   const [codeSnippets, setCodeSnippets] = useState({} as any);
 
   const [selectedViewport, setSelectedViewport] = useState<string | null>(
@@ -99,6 +105,10 @@ export const CodePreview = ({
     });
     setCodeSnippets(codeSnippets);
   }, [code]);
+
+  useEffect(() => {
+    defineCustomElement();
+  });
 
   let stackBlitzTooltip;
   if (controls?.stackblitz && typeof controls.stackblitz !== 'boolean') {
@@ -156,20 +166,21 @@ export const CodePreview = ({
           </div>
         </div>
         <div className="code-preview__preview">
-          {/* 
-            We render an iframe for each viewport.
-            When the selected viewport changes, we hide one frame
-            and show the other. This is done to avoid flickering
-            and doing unnecessary reloads when switching viewports.
-          */}
+          {/*
+           * We render an iframe for each viewport.
+           * When the selected viewport changes, we hide one frame
+           * and show the other. This is done to avoid flickering
+           * and doing unnecessary reloads when switching viewports.
+           */}
           {source &&
             viewport?.viewports.map(({ src, name }) => (
               <PreviewFrame
                 key={`frame-${name}`}
                 isVisible={selectedViewport === name}
-                baseUrl={source}
+                baseUrl={source!}
                 src={src}
                 size={size ?? 'sm'}
+                devicePreview={devicePreview}
                 isDarkMode={isDarkMode === true}
               />
             ))}

--- a/src/components/DevicePreview.ts
+++ b/src/components/DevicePreview.ts
@@ -1,0 +1,173 @@
+class DevicePreview extends HTMLElement {
+  static get observedAttributes() {
+    return ["mode"];
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+
+    if (this.shadowRoot) {
+      const _style = document.createElement("style");
+      _style.innerHTML = `
+   :host {
+     --device-padding: 1rem;
+     --device-width: 344px;
+     --device-height: 704px;
+     --device-frame-width: 12px;
+ 
+ 
+     display: flex;
+ 
+     align-items: center;
+     justify-content: center;
+   }
+ 
+   figure {
+     margin: 0;
+ 
+     background-size: contain;
+     background-repeat: no-repeat;
+ 
+     box-shadow: 0px 2px 8px rgba(2, 8, 20, 0.1), 0px 8px 16px rgba(2, 8, 20, 0.08);
+ 
+     width: var(--device-width);
+     height: var(--device-height);
+ 
+     overflow: hidden;
+ 
+     position: relative;
+ 
+     z-index: 1;
+   }
+ 
+   .content {
+    position: absolute;
+
+    top: 0;
+    left: 0;
+ 
+    width: 100%;
+    height: 100%;
+ 
+    border: none;
+
+    overflow: hidden;
+
+    -webkit-mask-image: -webkit-radial-gradient(white, black);
+
+    z-index: 1;
+   }
+ 
+   :host(.ios) figure {
+    border: 12px solid black;
+    border-radius: 54px;
+   }
+ 
+   :host(.ios) .content {
+     border-radius: 38px;
+   }
+   
+   :host(.ios) figure:after {
+     background-color: rgba(0, 0, 0, 0.5);
+     border-radius: 2px;
+     bottom: 8px;
+     content: '';
+     height: 4px;
+     left: 50%;
+     position: absolute;
+     transform: translateX(-50%);
+     width: 35%;
+     z-index: 1;
+   }
+ 
+   :host(.md) figure {
+     border: 12px solid black;
+     border-radius: 44px;
+   }
+ 
+   :host(.md) .content {
+     border-radius: 32px;
+   }
+ 
+   .ios-notch {
+     display: none;
+     fill: #090a0d;
+     left: 50%;
+     position: absolute;
+     top: 0px;
+     transform: translateX(-50%);
+     width: 165px;
+     z-index: 2;
+   }
+ 
+   .md-bar {
+     display: none;
+     fill: rgba(125, 125, 125, 0.3);
+     padding: 0.5rem 2.2rem;
+     position: relative;
+     width: calc(100% - 64px);
+     z-index: 2;
+     top: 0px;
+   }
+ 
+   :host(.ios) .ios-notch {
+     display: block;
+   }
+ 
+   :host(.md) .md-bar {
+     display: block;
+   }  
+
+   ::slotted(iframe) {
+     height: 100%;
+   }
+ 
+ `;
+
+      const _template = document.createElement("template");
+      _template.innerHTML = `
+        <figure>
+          <svg class="md-bar" viewBox="0 0 1384.3 40.3">
+            <path class="st0" d="M1343 5l18.8 32.3c.8 1.3 2.7 1.3 3.5 0L1384 5c.8-1.3-.2-3-1.7-3h-37.6c-1.5 0-2.5 1.7-1.7 3z"></path>
+            <circle class="st0" cx="1299" cy="20.2" r="20"></circle>
+            <path class="st0" d="M1213 1.2h30c2.2 0 4 1.8 4 4v30c0 2.2-1.8 4-4 4h-30c-2.2 0-4-1.8-4-4v-30c0-2.3 1.8-4 4-4zM16 4.2h64c8.8 0 16 7.2 16 16s-7.2 16-16 16H16c-8.8 0-16-7.2-16-16s7.2-16 16-16z"></path>
+          </svg>
+          <svg class="ios-notch" viewBox="0 0 219 31">
+            <path d="M0 1V0h219v1a5 5 0 0 0-5 5v3c0 12.15-9.85 22-22 22H27C14.85 31 5 21.15 5 9V6a5 5 0 0 0-5-5z" fill-rule="evenodd"></path>
+          </svg>
+          <div class="content">
+            <slot></slot>
+          </div>
+        </figure>
+      `;
+
+      this.shadowRoot.appendChild(_style);
+      this.shadowRoot.appendChild(_template.content.cloneNode(true));
+    }
+  }
+
+  connectedCallback() {
+    this.modeChanged();
+  }
+
+  attributeChangedCallback(name: string, _previousValue: string, _nextValue: string) {
+    if (name === "mode") {
+      this.modeChanged();
+    }
+  }
+
+  modeChanged() {
+    const mode = this.getAttribute("mode");
+    if (this.shadowRoot) {
+      this.shadowRoot.host.classList.toggle("ios", mode === "ios");
+      this.shadowRoot.host.classList.toggle("md", mode === "md");
+    }
+  }
+}
+
+export function defineCustomElement() {
+  if (window.customElements.get('device-preview') === undefined) {
+    window.customElements.define("device-preview", DevicePreview);
+  }
+}

--- a/src/components/DevicePreview.ts
+++ b/src/components/DevicePreview.ts
@@ -1,14 +1,14 @@
 class DevicePreview extends HTMLElement {
   static get observedAttributes() {
-    return ["mode"];
+    return ['mode'];
   }
 
   constructor() {
     super();
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({ mode: 'open' });
 
     if (this.shadowRoot) {
-      const _style = document.createElement("style");
+      const _style = document.createElement('style');
       _style.innerHTML = `
    :host {
      --device-padding: 1rem;
@@ -125,7 +125,7 @@ class DevicePreview extends HTMLElement {
  
  `;
 
-      const _template = document.createElement("template");
+      const _template = document.createElement('template');
       _template.innerHTML = `
         <figure>
           <svg class="md-bar" viewBox="0 0 1384.3 40.3">
@@ -151,23 +151,27 @@ class DevicePreview extends HTMLElement {
     this.modeChanged();
   }
 
-  attributeChangedCallback(name: string, _previousValue: string, _nextValue: string) {
-    if (name === "mode") {
+  attributeChangedCallback(
+    name: string,
+    _previousValue: string,
+    _nextValue: string
+  ) {
+    if (name === 'mode') {
       this.modeChanged();
     }
   }
 
   modeChanged() {
-    const mode = this.getAttribute("mode");
+    const mode = this.getAttribute('mode');
     if (this.shadowRoot) {
-      this.shadowRoot.host.classList.toggle("ios", mode === "ios");
-      this.shadowRoot.host.classList.toggle("md", mode === "md");
+      this.shadowRoot.host.classList.toggle('ios', mode === 'ios');
+      this.shadowRoot.host.classList.toggle('md', mode === 'md');
     }
   }
 }
 
 export function defineCustomElement() {
   if (window.customElements.get('device-preview') === undefined) {
-    window.customElements.define("device-preview", DevicePreview);
+    window.customElements.define('device-preview', DevicePreview);
   }
 }

--- a/src/components/PreviewFrame.tsx
+++ b/src/components/PreviewFrame.tsx
@@ -8,6 +8,9 @@ interface PreviewFrameProps {
    * or an explicit pixel value.
    */
   size: FrameSize | string;
+  /**
+   * The base URL of the site.
+   */
   baseUrl: string;
   /**
    * `true` if the selected viewport matches the frame source.
@@ -17,7 +20,13 @@ interface PreviewFrameProps {
    * `true` if the frame should display the preview in dark mode.
    */
   isDarkMode: boolean;
-
+  /**
+   * `true` if the iframe should be rendered inside of a device shell.
+   */
+  devicePreview?: boolean;
+  /**
+   * The title to be assigned to the iframe.
+   */
   title?: string;
 }
 
@@ -28,6 +37,7 @@ export const PreviewFrame = ({
   isVisible,
   isDarkMode,
   title,
+  devicePreview,
 }: PreviewFrameProps) => {
   const frameRef = useRef<HTMLIFrameElement>(null);
   const frameSrc = useMemo(() => src(baseUrl), [src, baseUrl]);
@@ -51,15 +61,31 @@ export const PreviewFrame = ({
       });
     }
   }, [isDarkMode]);
-  return (
-    <iframe
-      ref={frameRef}
-      src={frameSrc}
-      title={title}
-      height={[size in FRAME_SIZES] ? FRAME_SIZES[size as FrameSize] : size}
-      className={!isVisible ? 'frame-hidden' : ''}
-    />
-  );
+
+  function renderFrame() {
+    return (
+      <iframe
+        ref={frameRef}
+        src={frameSrc}
+        title={title}
+        height={[size in FRAME_SIZES] ? FRAME_SIZES[size as FrameSize] : size}
+        className={!isVisible ? 'frame-hidden' : ''}
+      />
+    );
+  }
+
+  if (devicePreview) {
+    const isIOS = frameSrc.includes('mode=ios');
+    return (
+      <div className={!isVisible ? 'frame-hidden' : ''}>
+        <device-preview mode={isIOS ? 'ios' : 'md'}>
+          {renderFrame()}
+        </device-preview>
+      </div>
+    );
+  }
+
+  return renderFrame();
 };
 
 const waitForFrame = (frame: HTMLIFrameElement) => {

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,5 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    'device-preview': any;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],
+    "target": "es2017",
     "importHelpers": true,
     // output .d.ts declaration files for consumers
     "declaration": true,
@@ -30,6 +31,6 @@
     // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
-    "noEmit": true,
+    "noEmit": true
   }
 }


### PR DESCRIPTION
Introduces new `devicePreview` option on `CodePreview` to allow rendering a device chrome around iframe examples. Supports swapping out between Android and iOS preview, based on `mode=ios` being present in the query params.